### PR TITLE
fix: fix the loading screen in login page

### DIFF
--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -83,15 +83,20 @@ function Login() {
           }
           dataUpdate();
         } else {
-          setLoading(false);
-          setTimeout(() => {
-            setLoading(true);
-          }, 2000);
+          // setLoading(false);
+          // setTimeout(() => {
+          //   setLoading(true);
+          // }, 2000);
+          // setErr(true);
+          // setTimeout(() => {
+          //   setErr(false);
+          // }, 5000);
+          // console.log("error");
           setErr(true);
           setTimeout(() => {
             setErr(false);
-          }, 5000);
-          console.log("error");
+          }, 1000);
+          setTimeout(() => setLoading(false), 1000);
         }
       });
     });


### PR DESCRIPTION
- Due to the loading screen that bugged, i tried to fix the state hooks in async process 
- To fix it, i change the state hooks position if the process has been failed by drag the default hooks state for loading in the end of process